### PR TITLE
Support opaque datapoint ids 

### DIFF
--- a/ampel/aux/SimpleTagFilter.py
+++ b/ampel/aux/SimpleTagFilter.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# File              : Ampel-core/ampel/aux/SimpleTagFilter.py
+# License           : BSD-3-Clause
+# Author            : Jakob van Santen <jakob.van.santen@desy.de>
+# Date              : 06.12.2021
+# Last Modified Date: 06.12.2021
+# Last Modified By  : Jakob van Santen <jakob.van.santen@desy.de>
+
+from typing import Optional
+from ampel.types import Tag
+from ampel.abstract.AbsApplicable import AbsApplicable
+from ampel.content.DataPoint import DataPoint
+
+
+class SimpleTagFilter(AbsApplicable):
+
+    #: Accept DataPoints with any of these tags
+    require: Optional[list[Tag]] = None
+    #: Reject Datapoints with any of these tags
+    forbid: Optional[list[Tag]] = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._allow = None if self.require is None else set(self.require)
+        self._deny = None if self.forbid is None else set(self.forbid)
+
+    def _accept(self, dp: DataPoint):
+        tag = set(dp.get("tag", []))
+        return (self._allow is None or tag.intersection(self._allow)) and (
+            self._deny is None or not tag.intersection(self._deny)
+        )
+
+    def apply(self, arg: list[DataPoint]) -> list[DataPoint]:
+        return [el for el in arg if self._accept(el)]

--- a/ampel/ingest/ChainedIngestionHandler.py
+++ b/ampel/ingest/ChainedIngestionHandler.py
@@ -176,26 +176,32 @@ class ChainedIngestionHandler:
 
 		# Create ingesters
 		dbconf = self.context.config.get(f'{database}.ingest', dict, raise_exc=True)
+		def get_ingester_model(key: str) -> UnitModel:
+			model = dbconf[key]
+			if isinstance(model, str):
+				return UnitModel(unit=model)
+			else:
+				return UnitModel(**model)
 		self.t0_ingester = AuxUnitRegister.new_unit(
-			model = UnitModel(unit=dbconf['t0']),
+			model = get_ingester_model('t0'),
 			sub_type = AbsDocIngester[DataPoint],
 			updates_buffer = updates_buffer
 		)
 
 		self.t1_ingester = AuxUnitRegister.new_unit(
-			model = UnitModel(unit=dbconf['t1']),
+			model = get_ingester_model('t1'),
 			sub_type = AbsDocIngester[T1Document],
 			updates_buffer = updates_buffer
 		)
 
 		self.t2_ingester = AuxUnitRegister.new_unit(
-			model = UnitModel(unit=dbconf['t2']),
+			model = get_ingester_model('t2'),
 			sub_type = AbsDocIngester[T2Document],
 			updates_buffer = updates_buffer
 		)
 
 		self.stock_ingester = AuxUnitRegister.new_unit(
-			model = UnitModel(unit=dbconf['stock']),
+			model = get_ingester_model('stock'),
 			sub_type = AbsDocIngester[StockDocument],
 			updates_buffer = updates_buffer
 		)

--- a/ampel/ingest/T0Compiler.py
+++ b/ampel/ingest/T0Compiler.py
@@ -15,7 +15,6 @@ from ampel.abstract.AbsDocIngester import AbsDocIngester
 from ampel.util.collections import try_reduce
 from ampel.abstract.AbsCompiler import AbsCompiler
 from ampel.enum.MetaActionCode import MetaActionCode
-from ampel.util.tag import merge_tags
 
 
 class T0Compiler(AbsCompiler):
@@ -77,8 +76,8 @@ class T0Compiler(AbsCompiler):
 			]
 			meta['traceid'] = {'shaper': trace_id}
 
-			if self._tag:
-				dp['tag'] = merge_tags(self._tag, dp.get('tag'))
+			if self._tag or dp.get('tag'):
+				dp['tag'] = [*(self._tag or []), *(dp.get('tag') or [])]
 				meta['activity'].append(self._ingest_tag_activity) # type: ignore
 
 			if self.origin and 'origin' not in dp:

--- a/ampel/mongo/update/MongoT0Ingester.py
+++ b/ampel/mongo/update/MongoT0Ingester.py
@@ -17,6 +17,9 @@ from ampel.abstract.AbsDocIngester import AbsDocIngester
 class MongoT0Ingester(AbsDocIngester[DataPoint]):
 	""" Inserts `DataPoint` into the t0 collection  """
 
+	#: raise DuplicateKeyError on attempts to upsert the same id with different bodies
+	check_id_collision: bool = True
+
 	def ingest(self, doc: DataPoint) -> None:
 
 		match: Dict[str, Any] = {'id': doc['id']}
@@ -31,6 +34,8 @@ class MongoT0Ingester(AbsDocIngester[DataPoint]):
 
 		if 'body' in doc:
 			upd['$setOnInsert'] = {'body': doc['body']}
+			if self.check_id_collision:
+				match['body'] = doc['body']
 
 		if 'origin' in doc:
 			match['origin'] = doc['origin']

--- a/ampel/test/test-data/testing-config.yaml
+++ b/ampel/test/test-data/testing-config.yaml
@@ -470,6 +470,14 @@ unit:
     distrib: ampel-core
     file: /Users/jakob/Documents/ZTF/Ampel-v0.8/ampel-core/conf/ampel-core/ampel.yaml
     version: 0.8.0a0
+  SimpleTagFilter:
+    fqn: ampel.aux.SimpleTagFilter
+    base:
+    - SimpleTagFilter
+    - AbsApplicable
+    distrib: ampel-core
+    file: /Users/jakob/Documents/ZTF/Ampel-v0.8/ampel-core/conf/ampel-core/ampel.yaml
+    version: 0.8.1a8
   SimpleDictArrayFilter:
     fqn: ampel.aux.filter.SimpleDictArrayFilter
     base:

--- a/ampel/test/test_IngestionHandler.py
+++ b/ampel/test/test_IngestionHandler.py
@@ -301,12 +301,11 @@ def test_multiplex_elision(
 
 
 def test_t0_meta_append(
-    dev_context: DevAmpelContext,
-    single_source_directive: IngestDirective,
+    mock_context: DevAmpelContext,
     datapoints: list[DataPoint],
 ):
     """T0Compiler preserves tags and meta entries"""
-    handler = get_handler(dev_context, [single_source_directive])
+    handler = get_handler(mock_context, [IngestDirective(channel="TEST_CHANNEL")])
     ts = 3.14159
     meta_record: MetaRecord = {
         "activity": [
@@ -325,7 +324,7 @@ def test_t0_meta_append(
     handler.t0_compiler.commit(handler.t0_ingester, ts)
     handler.updates_buffer.push_updates(force=True)
 
-    doc = dev_context.db.get_collection("t0").find_one({"id": datapoints[0]["id"]})
+    doc = mock_context.db.get_collection("t0").find_one({"id": datapoints[0]["id"]})
     assert doc["channel"] == ["SOME_CHANNEL"]
     assert set(tags).intersection(doc["tag"]), "initial datapoint tags set"
     assert set(doc["tag"]).difference(tags), "compiler adds its own tags"

--- a/ampel/test/test_IngestionHandler.py
+++ b/ampel/test/test_IngestionHandler.py
@@ -1,10 +1,14 @@
 from collections import defaultdict
-from typing import Any
-from ampel.content.MetaActivity import MetaActivity
+import contextlib
+from typing import Any, Generator
+from ampel.config.AmpelConfig import AmpelConfig
 from ampel.content.MetaRecord import MetaRecord
-from ampel.core.AmpelContext import AmpelContext
 from ampel.enum.MetaActionCode import MetaActionCode
+from ampel.util.freeze import recursive_unfreeze
+from ampel.view.ReadOnlyDict import ReadOnlyDict
+from pymongo.errors import DuplicateKeyError
 import pytest
+import mongomock
 
 from ampel.content.DataPoint import DataPoint
 from ampel.dev.DevAmpelContext import DevAmpelContext
@@ -84,7 +88,9 @@ def multiplex_directive(
 def get_handler(context: DevAmpelContext, directives) -> ChainedIngestionHandler:
     run_id = 0
     logger = AmpelLogger.get_logger(console={"level": DEBUG})
-    updates_buffer = DBUpdatesBuffer(context.db, run_id=run_id, logger=logger)
+    updates_buffer = DBUpdatesBuffer(
+        context.db, run_id=run_id, logger=logger, raise_exc=True
+    )
     return ChainedIngestionHandler(
         context=context,
         logger=logger,
@@ -105,7 +111,7 @@ def test_no_directive(dev_context):
 
 @pytest.fixture
 def datapoints() -> list[DataPoint]:
-    return [{"id": i, "stock": "stockystock"} for i in range(3)]
+    return [{"id": i, "stock": "stockystock", "body": {"thing": i}} for i in range(3)]
 
 
 def test_minimal_directive(
@@ -294,7 +300,7 @@ def test_multiplex_elision(
     ), "multiplexed channel contains additional datapoints"
 
 
-def test_t0_compiler(
+def test_t0_meta_append(
     dev_context: DevAmpelContext,
     single_source_directive: IngestDirective,
     datapoints: list[DataPoint],
@@ -320,7 +326,47 @@ def test_t0_compiler(
     handler.updates_buffer.push_updates(force=True)
 
     doc = dev_context.db.get_collection("t0").find_one({"id": datapoints[0]["id"]})
+    assert doc["channel"] == ["SOME_CHANNEL"]
     assert set(tags).intersection(doc["tag"]), "initial datapoint tags set"
     assert set(doc["tag"]).difference(tags), "compiler adds its own tags"
     assert len(doc["meta"]) > 1, "initial datapoint meta set"
     assert meta_record in doc["meta"], "compiler adds its own meta entries"
+
+
+@contextlib.contextmanager
+def unfreeze_config(context: DevAmpelContext) -> Generator[dict, None, None]:
+    config = context.config
+    writable_config = recursive_unfreeze(config.get()) # type: ignore[arg-type]
+    context.config = AmpelConfig(writable_config, freeze=False)
+    yield writable_config
+    context.config = config
+
+
+def test_duplicate_t0_id(
+    integration_context: DevAmpelContext,
+    datapoints: list[DataPoint],
+):
+    def run():
+        handler = get_handler(integration_context, [IngestDirective(channel="TEST_CHANNEL")])
+        handler.t0_compiler.add(datapoints, "SOME_CHANNEL", trace_id=0)
+        handler.t0_compiler.commit(handler.t0_ingester, 0)
+        handler.updates_buffer.push_updates(force=True)
+
+    # populate documents
+    run()
+
+    # fake an id collision by changing the body of an existing document without
+    # updating its id. when the consumer runs again below, this should cause the
+    # update operation to fail to match the body, and attempt to insert a duplicate
+    # id
+    datapoints[0]["body"]["broken"] = "boom"
+    with pytest.raises(DuplicateKeyError):
+        run()
+
+    # with id check disabled, no exception is raised
+    with unfreeze_config(integration_context) as config:
+        config["mongo"]["ingest"]["t0"] = {
+            "unit": "MongoT0Ingester",
+            "config": {"check_id_collision": False},
+        }
+        run()

--- a/ampel/test/test_SimpleTagFilter.py
+++ b/ampel/test/test_SimpleTagFilter.py
@@ -1,0 +1,37 @@
+from ampel.model.UnitModel import UnitModel
+import pytest
+
+from ampel.model.DPSelection import DPSelection
+
+
+@pytest.mark.parametrize(
+    "filter,count",
+    [
+        (None, 0),
+        ("SimpleTagFilter", 5),
+        (UnitModel(unit="SimpleTagFilter", config={"require": ["good"]}), 2),
+        (UnitModel(unit="SimpleTagFilter", config={"forbid": ["bad"]}), 3),
+        (
+            UnitModel(
+                unit="SimpleTagFilter", config={"require": ["good"], "forbid": ["bad"]}
+            ),
+            1,
+        ),
+    ],
+    ids=["none", "noop", "require", "forbid", "both"],
+)
+def test_SimpleTagFilter(mock_context, filter, count):
+    dp = DPSelection(filter=filter)
+    filterer, sorter, slicer = dp.tools()
+    if filter is None:
+        assert filterer is None
+    else:
+        datapoints = [
+            {"id": -2},
+            {"id": -1, "tag": []},
+            {"id": 0, "tag": ["good"]},
+            {"id": 1, "tag": ["bad"]},
+            {"id": 2, "tag": ["bad", "good"]},
+        ]
+
+        assert len(filterer.apply(datapoints)) == count

--- a/conf/ampel-core/ampel.yaml
+++ b/conf/ampel-core/ampel.yaml
@@ -47,6 +47,7 @@ unit:
 - ampel.dev.NoShaper
 
 # Aux units
+- ampel.aux.SimpleTagFilter
 - ampel.aux.filter.SimpleDictArrayFilter
 - ampel.aux.filter.FlatDictArrayFilter
 - ampel.t3.stage.project.T3ChannelProjector

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,7 +39,7 @@ python-versions = "*"
 
 [[package]]
 name = "ampel-interface"
-version = "0.8.1a10"
+version = "0.8.1a11"
 description = "Base classes for the Ampel analysis platform"
 category = "main"
 optional = false
@@ -47,7 +47,6 @@ python-versions = ">=3.9,<4.0"
 
 [package.dependencies]
 pydantic = ">=1.8.1,<2.0.0"
-pymongo = ">=4.0,<5.0"
 PyYAML = ">=5.4.1,<6.0.0"
 
 [package.extras]
@@ -979,7 +978,7 @@ server = ["fastapi", "uvicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.10"
-content-hash = "065e4a6fa990e8873a4a38372c6cbd64c1bc80eb627d9eb52006672557a31c2f"
+content-hash = "5d45051d70d7f0e405477e8ab42ead81cc37691d45495431ef2e4d8c8d539f15"
 
 [metadata.files]
 aiohttp = [
@@ -1065,8 +1064,8 @@ alabaster = [
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 ampel-interface = [
-    {file = "ampel-interface-0.8.1a10.tar.gz", hash = "sha256:49de4117f945c45bf8b2a8ffabccaa726e7eb918d4012677ef0d243abc33567f"},
-    {file = "ampel_interface-0.8.1a10-py3-none-any.whl", hash = "sha256:aba065c2afbc5e38d218d531a644c86598acbb3a74b7b86392c7e4adce9357ee"},
+    {file = "ampel-interface-0.8.1a11.tar.gz", hash = "sha256:854d7a593da1e58f821432f1db62997084214cd3af0cef69465062240b651ff5"},
+    {file = "ampel_interface-0.8.1a11-py3-none-any.whl", hash = "sha256:6a210f9c949620c19da1c3b2cc52ab5418ecd41c4b086cfc466b6381518c9701"},
 ]
 anyio = [
     {file = "anyio-3.4.0-py3-none-any.whl", hash = "sha256:2855a9423524abcdd652d942f8932fda1735210f77a6b392eafd9ff34d3fe020"},
@@ -1294,9 +1293,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1308,9 +1304,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1322,9 +1315,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1337,9 +1327,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1352,9 +1339,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ ampel = 'ampel.cli.main:main'
 'buffer Match and view or save ampel buffers' = 'ampel.cli.BufferCommand'
 
 [tool.poetry.dependencies]
-ampel-interface = {version = "^0.8.1-alpha.10"}
+ampel-interface = {version = "^0.8.1-alpha.11"}
 python = ">=3.9,<3.10"
 pydantic = "^1.8.1"
 pymongo = "^4.0"


### PR DESCRIPTION
DataPoints do not always come with unique ids, or ids that encode information. To support these cases, 

- Add collision detection to T0Compiler: if a DataPoint is added with the same `id` but a `body` different from an existing DataPoint, raise `DuplicateKeyError`. This can be disabled by setting `mongo.ingest.t0.unit.config.check_id_collision` to `False`.
- Refactor T1RetroCombiner to use DataPoints to construct substates, rather than just the ids.
- Add SimpleTagFilter to select inputs for point T2s based on tags.