### PR TITLE
Template values in jobs 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - master
+      - dev/*
 
 jobs:
   test:

--- a/ampel/cli/JobCommand.py
+++ b/ampel/cli/JobCommand.py
@@ -196,7 +196,7 @@ class JobCommand(AbsCoreCommand):
 				tds.append(morphed_um)
 
 			else:
-				tds.append(model.dict(exclude={"outputs"}))
+				tds.append(model.dict(exclude={"inputs", "outputs"}))
 
 			logger.info(f"Registering job task#{i} with {tds[-1]['multiplier']}x multiplier")
 

--- a/ampel/cli/JobCommand.py
+++ b/ampel/cli/JobCommand.py
@@ -196,7 +196,7 @@ class JobCommand(AbsCoreCommand):
 				tds.append(morphed_um)
 
 			else:
-				tds.append(model.dict())
+				tds.append(model.dict(exclude={"outputs"}))
 
 			logger.info(f"Registering job task#{i} with {tds[-1]['multiplier']}x multiplier")
 
@@ -254,7 +254,7 @@ class JobCommand(AbsCoreCommand):
 			else:
 
 				proc = ctx.loader.new_context_unit(
-					model = UnitModel(**task_dict),
+					model = UnitModel(**job.resolve_expressions(task_dict)),
 					context = ctx,
 					process_name = process_name,
 					sub_type = AbsEventUnit,

--- a/ampel/model/job/ExpressionParser.py
+++ b/ampel/model/job/ExpressionParser.py
@@ -1,0 +1,27 @@
+import ast
+from typing import Optional
+
+
+class ExpressionParser(ast.NodeVisitor):
+    @classmethod
+    def evaluate(cls, expression: str, parameters: dict[str, str]) -> str:
+        """Evaluate Argo-style template expressions"""
+        tree = ast.parse(expression, mode="eval")
+        self = cls(parameters)
+        self.visit(tree)
+        if self._value is None:
+            raise ValueError(f"unable to resolve {expression}")
+        return self._value
+
+    def __init__(self, parameters: dict[str, str]):
+        self._parameters = parameters
+        self._value : Optional[str] = None
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if (
+            isinstance(node.value, ast.Attribute)
+            and node.value.attr == "parameters"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "workflow"
+        ):
+            self._value = self._parameters.get(node.attr)

--- a/ampel/model/job/ExpressionParser.py
+++ b/ampel/model/job/ExpressionParser.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Optional
+from typing import Callable, Optional
 
 
 class ExpressionParser(ast.NodeVisitor):
@@ -15,7 +15,7 @@ class ExpressionParser(ast.NodeVisitor):
 
     def __init__(self, context: dict):
         self._context = context
-        self._value : Optional[str] = None
+        self._value: Optional[str] = None
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
         path = [node.attr]
@@ -33,3 +33,25 @@ class ExpressionParser(ast.NodeVisitor):
                 return
         if isinstance(context, str):
             self._value = context
+
+
+class ExpressionTransformer(ast.NodeVisitor):
+    """Translate top-level names"""
+
+    def __init__(self, name_mapping: Callable[[str], str]):
+        self._name_mapping = name_mapping
+        self._output = ""
+
+    def visit_Name(self, node: ast.Name):
+        super().generic_visit(node)
+        self._output += self._name_mapping(node.id)
+
+    def visit_Attribute(self, node: ast.Attribute):
+        super().generic_visit(node)
+        self._output += "." + node.attr
+
+    @classmethod
+    def transform(cls, expression: str, name_mapping: dict[str, str]):
+        self = cls(name_mapping)
+        self.visit(ast.parse(expression, mode="eval"))
+        return self._output

--- a/ampel/model/job/ExpressionParser.py
+++ b/ampel/model/job/ExpressionParser.py
@@ -4,24 +4,32 @@ from typing import Optional
 
 class ExpressionParser(ast.NodeVisitor):
     @classmethod
-    def evaluate(cls, expression: str, parameters: dict[str, str]) -> str:
+    def evaluate(cls, expression: str, context: dict) -> str:
         """Evaluate Argo-style template expressions"""
         tree = ast.parse(expression, mode="eval")
-        self = cls(parameters)
+        self = cls(context)
         self.visit(tree)
         if self._value is None:
             raise ValueError(f"unable to resolve {expression}")
         return self._value
 
-    def __init__(self, parameters: dict[str, str]):
-        self._parameters = parameters
+    def __init__(self, context: dict):
+        self._context = context
         self._value : Optional[str] = None
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
-        if (
-            isinstance(node.value, ast.Attribute)
-            and node.value.attr == "parameters"
-            and isinstance(node.value.value, ast.Name)
-            and node.value.value.id == "workflow"
-        ):
-            self._value = self._parameters.get(node.attr)
+        path = [node.attr]
+        parent = node.value
+        while isinstance(parent, ast.Attribute):
+            path.insert(0, parent.attr)
+            parent = parent.value
+        if isinstance(parent, ast.Name):
+            path.insert(0, parent.id)
+        context = self._context
+        while path:
+            try:
+                context = context[path.pop(0)]
+            except KeyError:
+                return
+        if isinstance(context, str):
+            self._value = context

--- a/ampel/model/job/ExpressionParser.py
+++ b/ampel/model/job/ExpressionParser.py
@@ -33,4 +33,6 @@ class ExpressionParser(ast.NodeVisitor):
                 return
         if isinstance(context, str):
             self._value = context
+        elif hasattr(context, "value"):
+            self._value = context.value()
 

--- a/ampel/model/job/ExpressionParser.py
+++ b/ampel/model/job/ExpressionParser.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Callable, Optional
+from typing import Any, Optional
 
 
 class ExpressionParser(ast.NodeVisitor):
@@ -25,7 +25,7 @@ class ExpressionParser(ast.NodeVisitor):
             parent = parent.value
         if isinstance(parent, ast.Name):
             path.insert(0, parent.id)
-        context = self._context
+        context: Any = self._context
         while path:
             try:
                 context = context[path.pop(0)]

--- a/ampel/model/job/ExpressionParser.py
+++ b/ampel/model/job/ExpressionParser.py
@@ -34,24 +34,3 @@ class ExpressionParser(ast.NodeVisitor):
         if isinstance(context, str):
             self._value = context
 
-
-class ExpressionTransformer(ast.NodeVisitor):
-    """Translate top-level names"""
-
-    def __init__(self, name_mapping: Callable[[str], str]):
-        self._name_mapping = name_mapping
-        self._output = ""
-
-    def visit_Name(self, node: ast.Name):
-        super().generic_visit(node)
-        self._output += self._name_mapping(node.id)
-
-    def visit_Attribute(self, node: ast.Attribute):
-        super().generic_visit(node)
-        self._output += "." + node.attr
-
-    @classmethod
-    def transform(cls, expression: str, name_mapping: dict[str, str]):
-        self = cls(name_mapping)
-        self.visit(ast.parse(expression, mode="eval"))
-        return self._output

--- a/ampel/model/job/JobModel.py
+++ b/ampel/model/job/JobModel.py
@@ -117,7 +117,7 @@ class JobModel(BaseModel):
         for match in re.finditer(r"\{\{(.*)\}\}", v):
             if match.span()[0] > pos:
                 chunks.append(v[pos : match.span()[0]])
-            chunks.append(transform(match.groups(1)[0].strip()))
+            chunks.append(transform(match.groups()[0].strip()))
             pos = match.span()[1]
         if pos < len(v):
             chunks.append(v[pos : len(v)])

--- a/ampel/model/job/JobModel.py
+++ b/ampel/model/job/JobModel.py
@@ -1,8 +1,12 @@
+import re
+
 from ampel.model.ChannelModel import ChannelModel
 from ampel.model.UnitModel import UnitModel
+from ampel.model.job.ExpressionParser import ExpressionParser
 from typing import Optional, Any, Union, Literal
 
 from pydantic import BaseModel, validator
+from ampel.util.recursion import walk_and_process_dict
 
 
 class TaskUnitModel(UnitModel):
@@ -22,11 +26,17 @@ class MongoOpts(BaseModel):
     prefix: str = "Ampel"
 
 
+class Parameter(BaseModel):
+    name: str
+    value: str
+
+
 class JobModel(BaseModel):
     name: str
     requirements: list[str] = []
     channel: list[dict[str, Any]] = []
     alias: dict[Literal["t0", "t1", "t2", "t3"], Any] = {}
+    parameters: list[Parameter] = []
     mongo: MongoOpts = MongoOpts()
     task: list[Union[TemplateUnitModel, TaskUnitModel]]
 
@@ -38,4 +48,31 @@ class JobModel(BaseModel):
         if not "channel" in v:
             v["channel"] = v.pop("name")
         ChannelModel(**v)
+        return v
+
+    @classmethod
+    def _resolve_parameters(cls, path, k, d, **kwargs):
+        for k, v in d.items():
+            if isinstance(v, str):
+                chunks = []
+                pos = 0
+                for match in re.finditer(r"\{\{(.*)\}\}", v):
+                    if match.span()[0] > pos:
+                        chunks.append(v[pos : match.span()[0]])
+                    chunks.append(
+                        ExpressionParser.evaluate(
+                            match.groups(1)[0].strip(), kwargs.get("parameters", {})
+                        )
+                    )
+                    pos = match.span()[1]
+                if pos < len(v):
+                    chunks.append(v[pos : len(v)])
+                d[k] = "".join(chunks)
+
+    @validator("task", pre=True)
+    def resolve_parameters(cls, v, values):
+        parameters = {param.name: param.value for param in values.get("parameters", [])}
+        walk_and_process_dict(
+            v, callback=cls._resolve_parameters, parameters=parameters
+        )
         return v

--- a/ampel/t3/supply/load/T3SimpleDataLoader.py
+++ b/ampel/t3/supply/load/T3SimpleDataLoader.py
@@ -8,7 +8,7 @@
 # Last Modified By  : vb <vbrinnel@physik.hu-berlin.de>
 
 from bson.codec_options import CodecOptions
-from typing import Iterable, Union, Iterator, Optional
+from typing import Iterable, Union, Iterator, Optional, ClassVar
 from ampel.types import StockId, StrictIterable
 from ampel.struct.AmpelBuffer import AmpelBuffer
 from ampel.abstract.AbsT3Loader import AbsT3Loader
@@ -18,7 +18,7 @@ from ampel.mongo.view.FrozenValuesDict import FrozenValuesDict
 class T3SimpleDataLoader(AbsT3Loader):
 	"""Load all requested documents for the selected stocks"""
 
-	codec_options: Optional[CodecOptions] = CodecOptions(document_class=FrozenValuesDict)
+	codec_options: ClassVar[Optional[CodecOptions]] = CodecOptions(document_class=FrozenValuesDict)
 
 	def load(self,
 		stock_ids: Union[StockId, Iterator[StockId], StrictIterable[StockId]]

--- a/ampel/test/dummy.py
+++ b/ampel/test/dummy.py
@@ -7,6 +7,7 @@
 # Last Modified Date: 11.02.2021
 # Last Modified By  : jvs
 
+import pathlib
 import time
 from typing import List, Optional, Sequence, Tuple, Union, Any
 
@@ -103,3 +104,20 @@ class DummyCompilerOptions(CompilerOptions):
     state_t2: dict[str, Any] = {"tag": "ZTF"}
     point_t2: dict[str, Any] = {"tag": "ZTF"}
     stock_t2: dict[str, Any] = {"tag": "ZTF"}
+
+
+class DummyOutputUnit(AbsEventUnit):
+
+    value: str
+    path: pathlib.Path
+
+    def run(self):
+        self.path.write_text(self.value)
+
+class DummyInputUnit(AbsEventUnit):
+
+    value: str
+    expected_value: str
+
+    def run(self):
+        assert self.value == self.expected_value

--- a/ampel/test/test-data/testing-config.yaml
+++ b/ampel/test/test-data/testing-config.yaml
@@ -608,6 +608,16 @@ unit:
     base:
       - DummyCompilerOptions
       - CompilerOptions
+  DummyInputUnit:
+    fqn: ampel.test.dummy
+    version: 0.8.0a1
+    base:
+      - AbsEventUnit
+  DummyOutputUnit:
+    fqn: ampel.test.dummy
+    version: 0.8.0a1
+    base:
+      - AbsEventUnit
 process:
   t0: {}
   t1: {}

--- a/ampel/test/test_JobModel.py
+++ b/ampel/test/test_JobModel.py
@@ -21,7 +21,9 @@ def test_resolve_parameters():
             ],
         }
     )
-    job.resolve_expressions(job.task[0].dict())["config"]["param"] == "foo-biz-bar"
+    job.resolve_expressions(job.task[0].dict(), job.task[0])["config"][
+        "param"
+    ] == "foo-biz-bar"
 
 
 def test_resolve_task_outputs(tmp_path: pathlib.Path):
@@ -47,7 +49,7 @@ def test_resolve_task_outputs(tmp_path: pathlib.Path):
             ],
         }
     )
-    job.resolve_expressions(job.task[1].dict())["config"]["token"] == token
+    job.resolve_expressions(job.task[1].dict(), job.task[1])["config"]["token"] == token
 
 
 def test_evaluate_expression():

--- a/ampel/test/test_JobModel.py
+++ b/ampel/test/test_JobModel.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ampel.model.job.JobModel import JobModel
+from ampel.model.job.ExpressionParser import ExpressionParser
+
+
+def test_resolve_parameters():
+    model_dict = {
+        "name": "job",
+        "task": [
+            {
+                "unit": "flerp",
+                "config": {"param": "foo{{ workflow.parameters.param }}bar"},
+            }
+        ],
+        "parameters": [
+            {"name": "param", "value": "-biz-"},
+        ],
+    }
+    assert JobModel(**model_dict).task[0].config["param"] == "foo-biz-bar"
+
+
+def test_evaluate_expression():
+    with pytest.raises(ValueError):
+        ExpressionParser.evaluate("workflow.parameters.param", {})
+        ExpressionParser.evaluate("thing.parameters.param", {})
+        ExpressionParser.evaluate("parameters.param", {})
+    assert (
+        ExpressionParser.evaluate("workflow.parameters.param", {"param": "foo"})
+        == "foo"
+    )

--- a/ampel/test/test_JobModel.py
+++ b/ampel/test/test_JobModel.py
@@ -26,7 +26,7 @@ def test_resolve_parameters():
     ] == "foo-biz-bar"
 
 
-def test_resolve_task_outputs(tmp_path: pathlib.Path):
+def test_resolve_task_outputs(tmp_path):
     token_path = tmp_path / "token"
     token_path.write_text(token := secrets.token_hex())
     job = JobModel(

--- a/ampel/test/test_JobModel.py
+++ b/ampel/test/test_JobModel.py
@@ -1,31 +1,67 @@
 import pytest
+import pathlib
+import secrets
 
 from ampel.model.job.JobModel import JobModel
 from ampel.model.job.ExpressionParser import ExpressionParser
 
 
 def test_resolve_parameters():
-    model_dict = {
-        "name": "job",
-        "task": [
-            {
-                "unit": "flerp",
-                "config": {"param": "foo{{ workflow.parameters.param }}bar"},
-            }
-        ],
-        "parameters": [
-            {"name": "param", "value": "-biz-"},
-        ],
-    }
-    assert JobModel(**model_dict).task[0].config["param"] == "foo-biz-bar"
+    job = JobModel(
+        **{
+            "name": "job",
+            "task": [
+                {
+                    "unit": "flerp",
+                    "config": {"param": "foo{{ job.parameters.param }}bar"},
+                }
+            ],
+            "parameters": [
+                {"name": "param", "value": "-biz-"},
+            ],
+        }
+    )
+    job.resolve_expressions(job.task[0].dict())["config"]["param"] == "foo-biz-bar"
+
+
+def test_resolve_task_outputs(tmp_path: pathlib.Path):
+    token_path = tmp_path / "token"
+    token_path.write_text(token := secrets.token_hex())
+    job = JobModel(
+        **{
+            "name": "job",
+            "task": [
+                {
+                    "unit": "bloop",
+                    "config": {"output": str(token_path)},
+                    "outputs": {
+                        "parameters": [
+                            {"name": "token", "value_from": {"path": str(token_path)}}
+                        ]
+                    },
+                },
+                {
+                    "unit": "flerp",
+                    "config": {"token": "{{ task.bloop.outputs.parameters.token }}"},
+                },
+            ],
+        }
+    )
+    job.resolve_expressions(job.task[1].dict())["config"]["token"] == token
 
 
 def test_evaluate_expression():
     with pytest.raises(ValueError):
-        ExpressionParser.evaluate("workflow.parameters.param", {})
-        ExpressionParser.evaluate("thing.parameters.param", {})
-        ExpressionParser.evaluate("parameters.param", {})
+        ExpressionParser.evaluate("job.parameters.param", {})
+        ExpressionParser.evaluate(
+            "thing.parameters.param", {"parameters": {"param": "foo"}}
+        )
+        ExpressionParser.evaluate(
+            "parameters.param", {"thing": {"parameters": {"param": "foo"}}}
+        )
     assert (
-        ExpressionParser.evaluate("workflow.parameters.param", {"param": "foo"})
+        ExpressionParser.evaluate(
+            "job.parameters.param", {"job": {"parameters": {"param": "foo"}}}
+        )
         == "foo"
     )

--- a/ampel/test/test_JobModel.py
+++ b/ampel/test/test_JobModel.py
@@ -3,7 +3,7 @@ import pathlib
 import secrets
 
 from ampel.model.job.JobModel import JobModel
-from ampel.model.job.ExpressionParser import ExpressionParser, ExpressionTransformer
+from ampel.model.job.ExpressionParser import ExpressionParser
 
 
 def test_resolve_parameters():
@@ -65,26 +65,3 @@ def test_evaluate_expression():
         )
         == "foo"
     )
-
-
-def test_transform_expression():
-    replacements = {"job": "workflow"}
-    def name_mapping(name: str) -> str:
-        print(name)
-        return replacements.get(name, name)
-    assert (
-        ExpressionTransformer.transform("job.parameters.job", name_mapping=name_mapping)
-        == "workflow.parameters.job"
-    )
-
-    def transform(expression: str) -> str:
-        return (
-            "{{ "
-            + ExpressionTransformer.transform(expression, name_mapping=name_mapping)
-            + " }}"
-        )
-
-    assert JobModel.transform_expressions(
-        {"foo": {"bar": ["baz", "flim{{ job.parameters.job }}bim"]}},
-        transformation=transform,
-    ) == {"foo": {"bar": ["baz", "flim{{ workflow.parameters.job }}bim"]}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-core"
-version = "0.8.2-alpha.16"
+version = "0.8.2-alpha.17"
 description = "Asynchronous and Modular Platform with Execution Layers"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]


### PR DESCRIPTION
Allow `ampel job` to interpret template expressions in task definitions. Only two kinds of expressions are supported:

- job parameters, e.g. "{{ job.parameters.param }}" resolves to the job-level parameter "param"
- outputs of other tasks, e.g. "{{ task.step-0.outputs.parameters.token }}" resolves to the contents of the output file declared as "token" by the task named "step-0".
- task inputs, e.g. "{{ inputs.parameters.token }}" resolves to the local parameter "token", which may itself refer to an artifact that should be downloaded before the task runs via e.g. "{{ inputs.artifacts.token-to-get }}"

The first of these allows job authors to indicate which task parameters are intended to be easily settable, e.g. input filenames. `ampel job` always reads these from the job definition; there is no way to set them from the command line. The second allows the configuration of tasks to depend on previous tasks, e.g. like so: https://github.com/AmpelProject/Ampel-core/blob/eb8d9609468694b934a2d8ec0cc59fa233334ea7/ampel/test/test_JobCommand.py#L148-L169 This can be useful e.g. for creating an ephemeral stream token to pass to ZTFArchiveAlertSupplier, where the semantic value is in the query that created the stream rather than the literal value of the token itself.

This syntax is inspired by Argo's template syntax, and comes with restrictions:

- template expressions must resolve to strings (i.e. evaluation cannot change the type of the value)
- expressions are only evaluated for leaf values, i.e. str in dict and str in list. dict keys may not contain templates expressions