### PR TITLE
Robustify T2DocView config resolution in T3

### DIFF
--- a/ampel/dev/DevAmpelContext.py
+++ b/ampel/dev/DevAmpelContext.py
@@ -55,6 +55,10 @@ class DevAmpelContext(AmpelContext):
 			self.db.drop_all_databases()
 			self.db.init_db()
 
+		for stored_conf in self.db.get_collection("conf").find({}):
+			confid = stored_conf.pop("_id")
+			dict.__setitem__(self.config._config["confid"], confid, stored_conf)
+
 
 	def add_channel(self, name: int | str, access: list[str] = []):
 		cm = ChannelModel(channel=name, access=access, version=0)

--- a/ampel/t3/stage/SimpleViewGenerator.py
+++ b/ampel/t3/stage/SimpleViewGenerator.py
@@ -10,6 +10,7 @@
 from typing import Iterable
 from collections.abc import Generator
 from ampel.abstract.AbsT3ReviewUnit import AbsT3ReviewUnit
+from ampel.config.AmpelConfig import AmpelConfig
 from ampel.struct.AmpelBuffer import AmpelBuffer
 from ampel.mongo.update.MongoStockUpdater import MongoStockUpdater
 from ampel.t3.stage.BaseViewGenerator import BaseViewGenerator, T, T3Send
@@ -20,7 +21,8 @@ class SimpleViewGenerator(BaseViewGenerator[T]):
 	def __init__(self,
 		unit: AbsT3ReviewUnit,
 		buffers: Iterable[AmpelBuffer],
-		stock_updr: MongoStockUpdater
+		stock_updr: MongoStockUpdater,
+		config: AmpelConfig,
 	) -> None:
 
 		super().__init__(unit_name = unit.__class__.__name__, stock_updr = stock_updr)
@@ -28,10 +30,11 @@ class SimpleViewGenerator(BaseViewGenerator[T]):
 		self.View = unit._View
 		# ensure this generator's queue is consumed at most once 
 		self._it = iter(self.buffers)
+		self._config = config
 
 	def __iter__(self) -> Generator[T, T3Send, None]:
 		View = self.View
 		l = self.stocks
 		for ab in self._it:
 			l.append(ab['id'])
-			yield View.of(ab, freeze=True)
+			yield View.of(ab, self._config, freeze=True)

--- a/ampel/t3/stage/T3SimpleStager.py
+++ b/ampel/t3/stage/T3SimpleStager.py
@@ -48,7 +48,7 @@ class T3SimpleStager(T3ThreadedStager):
 		if len(self.units) == 1:
 			return self.proceed(
 				self.units[0],
-				SimpleViewGenerator(self.units[0], gen, self.stock_updr),
+				SimpleViewGenerator(self.units[0], gen, self.stock_updr, self.context.config),
 				t3s
 			)
 

--- a/ampel/t3/stage/ThreadedViewGenerator.py
+++ b/ampel/t3/stage/ThreadedViewGenerator.py
@@ -29,5 +29,8 @@ class ThreadedViewGenerator(BaseViewGenerator[T]):
 	def __iter__(self) -> Generator[T, T3Send, None]:
 		for view in self._it:
 			self.stocks.append(view.id)
-			yield view
-			self.queue.task_done()
+			try:
+				yield view
+			finally:
+				# mark item as done even if the consumer raises an exception
+				self.queue.task_done()

--- a/ampel/t3/supply/select/T3StockSelector.py
+++ b/ampel/t3/supply/select/T3StockSelector.py
@@ -7,6 +7,7 @@
 # Last Modified Date:  16.08.2022
 # Last Modified By:    valery brinnel <firstname.lastname@gmail.com>
 
+from collections.abc import Collection
 from pymongo.cursor import Cursor
 from typing import Literal, Any
 from ampel.types import ChannelId, Tag
@@ -92,7 +93,7 @@ class T3StockSelector(AbsT3Selector):
 			self.logger.log(
 				VERBOSE,
 				f"Executing stock search query [{col.database.name} "
-				f"{try_reduce(list(col.database.client.nodes))}]",
+				f"{try_reduce(list(col.database.client.nodes)) if isinstance(col.database.client.nodes, Collection) else None}]",
 				extra=safe_query_dict(match_query)
 			)
 

--- a/ampel/test/test_AmpelContext.py
+++ b/ampel/test/test_AmpelContext.py
@@ -1,0 +1,53 @@
+import copy
+
+from ampel.config.AmpelConfig import AmpelConfig
+from ampel.dev.DevAmpelContext import DevAmpelContext
+from ampel.test.dummy import DummyStateT2Unit
+
+
+def test_load_old_configids(mock_context: DevAmpelContext, ampel_logger):
+    """
+    Configuration hashes stored via hash_ingest_directive are loaded from the
+    database when a new DevAmpelContext is instantiated
+    """
+    unit_config = {"foo": 37}
+    mock_context.register_unit(DummyStateT2Unit)
+    pre_register_context = DevAmpelContext(
+        config=AmpelConfig(copy.deepcopy(mock_context.config.get())),
+        db=mock_context.db,
+        loader=mock_context.loader,
+    )
+    mock_context.hash_ingest_directive(
+        dict(
+            channel="TEST",
+            ingest=dict(
+                combine=[
+                    dict(
+                        unit="T1SimpleCombiner",
+                        state_t2=[dict(unit="DummyStateT2Unit", config=unit_config)],
+                    )
+                ]
+            ),
+        ),
+        ampel_logger,
+    )
+    post_register_context = DevAmpelContext(
+        config=AmpelConfig(copy.deepcopy(pre_register_context.config.get())),
+        db=mock_context.db,
+        loader=mock_context.loader,
+    )
+    assert (
+        isinstance(
+            pre_register_confid := pre_register_context.config.get("confid", dict), dict
+        )
+        and len(pre_register_confid) == 0
+    ), "config not present before registration"
+
+    assert (
+        isinstance(confid := mock_context.config.get("confid", dict), dict)
+        and len(confid) == 1
+    ), "config present after registration"
+    assert next(iter(confid.values())) == unit_config
+    assert (
+        post_register_context.config.get("confid", dict) == confid
+    ), "unregistered configs loaded from database"

--- a/ampel/test/test_T3Processor.py
+++ b/ampel/test/test_T3Processor.py
@@ -8,13 +8,20 @@
 # Last Modified By:    valery brinnel <firstname.lastname@gmail.com>
 
 from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from ampel.content.StockDocument import StockDocument
+from ampel.content.T2Document import T2Document
 from ampel.dev.DevAmpelContext import DevAmpelContext
+from ampel.enum.DocumentCode import DocumentCode
 from ampel.struct.JournalAttributes import JournalAttributes
 from ampel.struct.StockAttributes import StockAttributes
 from ampel.enum.EventCode import EventCode
 from ampel.view.SnapView import SnapView
 from ampel.struct.T3Store import T3Store
-import pytest
+from ampel.test.dummy import DummyStateT2Unit
 
 from ampel.abstract.AbsT3ReviewUnit import AbsT3ReviewUnit, T3Send
 from ampel.t3.T3Processor import T3Processor
@@ -179,3 +186,85 @@ def test_empty_generator(integration_context: DevAmpelContext, ingest_stock):
         ]
     )
     t3.run()
+
+
+class ViewExaminer(AbsT3ReviewUnit):
+    class DidAThing(Exception):
+        ...
+
+    expected_config: dict[str, Any]
+
+    def process(self, views, t3s=None):
+        for view in views:
+            for t2 in view.t2:
+                assert t2.config == self.expected_config
+                raise self.DidAThing
+
+
+@pytest.mark.parametrize("num_units", [1, 2])
+def test_t2_config_resolution(mock_context: DevAmpelContext, num_units: int):
+    """
+    T3 stagers pass through resolved config ids
+    """
+    for unit in (ViewExaminer, DummyStateT2Unit):
+        mock_context.register_unit(unit)
+
+    expected_config = {"foo": 42}
+    config_id = mock_context.gen_config_id("DummyStateT2Unit", expected_config)
+
+    stock: StockDocument = {
+        "stock": 0,
+    }
+    t2: T2Document = {
+        "unit": "DummyStateT2Unit",
+        "config": config_id,
+        "stock": 0,
+        "link": 0,
+        "channel": "TEST",
+        "meta": [],
+        "body": [],
+        "code": DocumentCode.OK,
+    }
+    mock_context.db.get_collection("stock").insert_one(dict(stock))
+    mock_context.db.get_collection("t2").insert_one(dict(t2))
+
+    t3 = T3Processor(
+        context=mock_context,
+        raise_exc=True,
+        process_name="t3",
+        execute=[
+            {
+                "unit": "T3ReviewUnitExecutor",
+                "config": {
+                    "supply": {
+                        "unit": "T3DefaultBufferSupplier",
+                        "config": {
+                            "select": {
+                                "unit": "T3StockSelector",
+                            },
+                            "load": {
+                                "unit": "T3SimpleDataLoader",
+                                "config": {
+                                    "directives": [{"col": "t2"}],
+                                },
+                            },
+                        },
+                    },
+                    "stage": {
+                        "unit": "T3SimpleStager",
+                        "config": {
+                            "execute": [
+                                {
+                                    "unit": "ViewExaminer",
+                                    "config": {"expected_config": expected_config},
+                                }
+                            ]
+                            * num_units
+                        },
+                    },
+                },
+            }
+        ],
+    )
+    with pytest.raises(ViewExaminer.DidAThing):
+        t3.run()


### PR DESCRIPTION
Fix bugs that caused `T2DocView.config` to always be `None` at T3 if any of the following were true:

- config ids came from IngestionDirectives hashed in a different DevAmpelContext
- views were provided by `T3SimpleStager` with a single unit. For multiple units, `T3ThreadedStager` resolved the configs correctly.
- the hash value was negative (fixed in ampel-interface 0.8.4)