### PR TITLE
JobCommand: reimplement urlretrieve with requests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -130,7 +130,7 @@ name = "charset-normalizer"
 version = "3.1.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7.0"
 files = [
     {file = "charset-normalizer-3.1.0.tar.gz", hash = "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"},
@@ -1101,7 +1101,7 @@ name = "requests"
 version = "2.28.2"
 description = "Python HTTP for Humans."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7, <4"
 files = [
     {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
@@ -1457,6 +1457,21 @@ files = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.28.11.15"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-requests-2.28.11.15.tar.gz", hash = "sha256:fc8eaa09cc014699c6b63c60c2e3add0c8b09a410c818b5ac6e65f92a26dde09"},
+    {file = "types_requests-2.28.11.15-py3-none-any.whl", hash = "sha256:a05e4c7bc967518fba5789c341ea8b0c942776ee474c7873129a61161978e586"},
+]
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
 name = "types-setuptools"
 version = "65.7.0.4"
 description = "Typing stubs for setuptools"
@@ -1470,6 +1485,18 @@ files = [
 
 [package.dependencies]
 types-docutils = "*"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.8"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.8.tar.gz", hash = "sha256:ecf43c42d8ee439d732a1110b4901e9017a79a38daca26f08e42c8460069392c"},
+    {file = "types_urllib3-1.26.25.8-py3-none-any.whl", hash = "sha256:95ea847fbf0bf675f50c8ae19a665baedcf07e6b4641662c4c3c72e7b2edf1a9"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -1563,7 +1590,7 @@ name = "urllib3"
 version = "1.26.14"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "urllib3-1.26.14-py2.py3-none-any.whl", hash = "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"},
@@ -1905,4 +1932,4 @@ slack = ["slack-sdk"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "c52794aecc057c0eaa9ac7130154b9e40f610f99e12d2a8ce57955b4159112c6"
+content-hash = "af1429b6db8abd750625786a833d0a0f99c68e92f46bac58ed6edeb2269d0e42"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ prometheus-client = ">=0.16,<0.17"
 xxhash = "^3.0.0"
 psutil = "^5.8.0"
 appdirs = "^1.4.4"
+requests = "^2.0"
 fastapi = {version = ">=0.92,<0.93", optional = true}
 uvicorn = {version = ">=0.20.0,<0.21.0", optional = true, extras = ["standard"]}
 Sphinx = {version = ">=6.1.2,<6.2.0", optional = true}
@@ -78,6 +79,9 @@ types-PyYAML = "^6.0.12"
 server = ["fastapi", "uvicorn"]
 docs = ["Sphinx", "sphinx-press-theme", "sphinx-autodoc-typehints", "tomlkit"]
 slack = ["slack_sdk"]
+
+[tool.poetry.group.dev.dependencies]
+types-requests = "^2.28.11.15"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
urllib.request.urlretrieve fails to set the `Host:` header, required for hosts like cdn.discordapp.com that are protected by cloudflare. Who knew?