### PR TITLE
Hash nested T2 configs

### DIFF
--- a/ampel/config/builder/ProcessMorpher.py
+++ b/ampel/config/builder/ProcessMorpher.py
@@ -237,7 +237,7 @@ class ProcessMorpher:
 		walk_and_process_dict(
 			arg = target or self.process["processor"]["config"]["directives"],
 			callback = self._gather_t2_config_callback,
-			match = ['point_t2', 'stock_t2', 'state_t2'],
+			match = ['point_t2', 'stock_t2', 'state_t2', 't2_dependency'],
 			conf_dicts = conf_dicts
 		)
 

--- a/ampel/test/test_HashT2Config.py
+++ b/ampel/test/test_HashT2Config.py
@@ -1,0 +1,53 @@
+import copy
+
+from ampel.config.alter.HashT2Config import HashT2Config
+from ampel.dev.DevAmpelContext import DevAmpelContext
+from ampel.test.dummy import DummyStateT2Unit, DummyTiedStateT2Unit
+
+
+def test_recursive_hash(mock_context: DevAmpelContext, ampel_logger):
+    """
+    HashT2Config.alter should hash nested t2 configs
+    """
+    unit_config = {
+        "t2_dependency": [{"unit": "DummyStateT2Unit", "config": {"foo": 37}}]
+    }
+    for u in (DummyStateT2Unit, DummyTiedStateT2Unit):
+        mock_context.register_unit(u)
+
+    hashed = HashT2Config().alter(
+        mock_context,
+        dict(
+            directives=[
+                dict(
+                    channel="TEST",
+                    ingest=dict(
+                        combine=[
+                            dict(
+                                unit="T1SimpleCombiner",
+                                state_t2=[
+                                    dict(
+                                        unit="DummyTiedStateT2Unit",
+                                        config=copy.deepcopy(unit_config),
+                                    )
+                                ],
+                            )
+                        ]
+                    ),
+                )
+            ]
+        ),
+        ampel_logger,
+    )
+
+    toplevel_config_id = hashed["directives"][0]["ingest"]["combine"][0]["state_t2"][0][
+        "config"
+    ]
+    assert isinstance(toplevel_config_id, int)
+    toplevel_config = mock_context.get_config().get_conf_id(toplevel_config_id)
+    nested_config_id = toplevel_config["t2_dependency"][0]["config"]
+    assert isinstance(nested_config_id, int)
+    assert (
+        mock_context.get_config().get_conf_id(nested_config_id)
+        == unit_config["t2_dependency"][0]["config"]
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-core"
-version = "0.10.2"
+version = "0.10.3"
 description = "Alice in Modular Provenance-Enabled Land"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 packages = [{include = "ampel"}]
+exclude = [
+    "ampel/py.typed",
+]
 include = [
     'conf/*/*.json',
     'conf/*/*/*.json',


### PR DESCRIPTION
Between v0.8 and v0.9, DevAmpelContext's hash_t2_configs was moved into an AbsConfigUpdater, `HashT2Config`, but lost the ability to hash t2 configs nested in dependencies. Put it back.