### PR TITLE
Remove pkg_resources

### DIFF
--- a/ampel/cli/JobCommand.py
+++ b/ampel/cli/JobCommand.py
@@ -8,6 +8,8 @@
 # Last Modified By:    valery brinnel <firstname.lastname@gmail.com>
 
 import filecmp
+import importlib
+import importlib.metadata
 import io
 import os
 import platform
@@ -23,7 +25,6 @@ from multiprocessing import Process, Queue
 from time import sleep, time
 from typing import Any
 
-import pkg_resources
 import psutil
 import ujson
 import yaml
@@ -371,7 +372,7 @@ class JobCommand(AbsCoreCommand):
 			for k in config_dict['build']:
 				if 'ampel-' in k:
 					config_v = config_dict['build'][k]
-					current_v = pkg_resources.get_distribution(k).version
+					current_v = importlib.metadata.distribution(k).version
 					if (
 						config_v != current_v and
 						yes_no(

--- a/ampel/config/builder/ConfigBuilder.py
+++ b/ampel/config/builder/ConfigBuilder.py
@@ -10,6 +10,7 @@
 import datetime
 import getpass
 import importlib
+import importlib.metadata
 import json
 import os
 import re
@@ -19,7 +20,6 @@ from collections.abc import Iterable
 from multiprocessing import Pool
 from typing import Any
 
-import pkg_resources
 import yaml
 
 from ampel.abstract.AbsChannelTemplate import AbsChannelTemplate
@@ -435,7 +435,7 @@ class ConfigBuilder:
 		}
 
 		for k in ('ampel-interface', 'ampel-core'):
-			d['build'][k] = pkg_resources.get_distribution(k).version
+			d['build'][k] = importlib.metadata.distribution(k).version
 
 		dists: set[tuple[str, str | float | int]] = set()
 		for k in ('unit', 'channel'):

--- a/ampel/config/collector/UnitConfigCollector.py
+++ b/ampel/config/collector/UnitConfigCollector.py
@@ -64,7 +64,7 @@ class UnitConfigCollector(AbsDictConfigCollector):
 					if el.split('.')[-1][0].islower():
 						package_path = el.replace(".", sep)
 						try:
-							for fpath in get_files(dist_name, lookup_dir=package_path):
+							for fpath in map(str, get_files(dist_name, lookup_dir=package_path)):
 								if sep in fpath.replace(package_path + sep, ""):
 									continue
 								self.add(

--- a/ampel/test/test_config.py
+++ b/ampel/test/test_config.py
@@ -159,7 +159,7 @@ def test_collect_bad_unit(tmp_path: Path, mocker: MockerFixture) -> None:
 
     mocker.patch(
         "ampel.config.builder.DistConfigBuilder.get_files",
-        return_value=[str(bad_unit_config)],
+        return_value=[bad_unit_config],
     )
 
     cb.load_distributions()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1761,26 +1761,6 @@ files = [
 test = ["pytest"]
 
 [[package]]
-name = "setuptools"
-version = "75.7.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "setuptools-75.7.0-py3-none-any.whl", hash = "sha256:84fb203f278ebcf5cd08f97d3fb96d3fbed4b629d500b29ad60d11e00769b183"},
-    {file = "setuptools-75.7.0.tar.gz", hash = "sha256:886ff7b16cd342f1d1defc16fc98c9ce3fde69e087a4e1983d7ab634e5f41f4f"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.8.0)"]
-core = ["importlib_metadata (>=6)", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.14.*)", "pytest-mypy"]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2540,4 +2520,4 @@ transform = ["yq"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3ce466c88d1a1ce291d57b86c6187aef28d565e4f103bf3a1be1084e3e77aea6"
+content-hash = "844d4a93e5d7bedc4c4a79f23ef2385bec092bfeb12daeb1261a69a4a7877ab3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,7 @@ pytest-cov = "^6.0.0"
 mypy = "^1.13.0"
 pytest-asyncio = "^0.25.0"
 pytest-mock = "^3.14.0"
-mongomock = "^4.1.2"
-# mongomock uses pkg_resources
-setuptools = {version = "*", python = ">=3.12"}
+mongomock = "^4.3"
 httpx = "^0.28.0"
 types-setuptools = "^65.1.0"
 types-PyYAML = "^6.0.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,6 @@ filterwarnings = [
     "default:unclosed:ResourceWarning",
     # warning deep in fastapi
     "ignore:.*general_plain_validator_function.*:DeprecationWarning",
-    "ignore:pkg_resources is deprecated:DeprecationWarning",
-    "ignore:Deprecated call to `pkg_resources:DeprecationWarning",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
`pkg_resources` is gone as of Python 3.12; replace uses with simpler equivalents from `importlib.metadata`

Along the way, simplify some things:
- Remove unused DistConfigBuilder.load_tier_conf_file
- Load JSON with pyyaml, since JSON is a subset of YAML