### PR TITLE
UnitLoader: resolve secrets in nested models

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "ampel-interface"
-version = "0.10.5a1"
+version = "0.10.5a2"
 description = "Base classes for the Ampel analysis platform"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "ampel_interface-0.10.5a1-py3-none-any.whl", hash = "sha256:0933f27121aa2dd8b0083b658c136f2639f7d59c856d230efff57a622e4a049a"},
-    {file = "ampel_interface-0.10.5a1.tar.gz", hash = "sha256:1ebb54371f0511442d053de02a263d07a99f701f69265200ef3add7a17753ea4"},
+    {file = "ampel_interface-0.10.5a2-py3-none-any.whl", hash = "sha256:e264fe510adeff0ae6ab0c8323a9f2797d23719f718fa5d80e8bb8f0086f05c9"},
+    {file = "ampel_interface-0.10.5a2.tar.gz", hash = "sha256:78099785509acd567f2c52281dabeef4f411ebbf262fcf74c8ce78c16b1a0ea4"},
 ]
 
 [package.dependencies]
@@ -2522,4 +2522,4 @@ transform = ["yq"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "f9565ad3de3780fb76774c112e33d087a91473cbe4deba4d0f9147290fefa413"
+content-hash = "eaec295237344869c9b023c2965bd55e60a664115a5575c2aac919830146fbde"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-core"
-version = "0.10.5a2"
+version = "0.10.5a3"
 description = "Alice in Modular Provenance-Enabled Land"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]
@@ -46,7 +46,7 @@ ampel = 'ampel.cli.main:main'
 'event_Show_events_information' = 'ampel.cli.EventCommand'
 
 [tool.poetry.dependencies]
-ampel-interface = {version = ">=0.10.5a1,<0.11"}
+ampel-interface = {version = ">=0.10.5a2,<0.11"}
 python = "^3.10"
 pymongo = "^4.0"
 schedule = "^1.0.0"


### PR DESCRIPTION
Call unit `__init__` (and potentially `post_init`) in a context where NamedSecret resolves its value from the currently configured vault. This allows models, including (nested) auxiliary units, to use secrets as long as they are instantiated in this context. Secrets held by the models remain populated, and so can be used later.

This is vastly simpler than trying to reverse-engineer the selection logic for e.g. discriminated unions, and recurses properly into nested models. 