### PR TITLE
Encapsulate setup/teardown in context managers

### DIFF
--- a/ampel/abstract/AbsContextManager.py
+++ b/ampel/abstract/AbsContextManager.py
@@ -1,0 +1,19 @@
+
+from types import TracebackType
+from typing import Self
+
+from ampel.base.AmpelABC import AmpelABC
+from ampel.base.decorator import abstractmethod
+
+
+class AbsContextManager(AmpelABC, abstract=True):
+    """
+    AmpelABC version of contextlib.AbstractContextManager
+    """
+
+    def __enter__(self) -> "Self":
+        return self
+
+    @abstractmethod
+    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None | bool:
+        ...

--- a/ampel/abstract/AbsIngester.py
+++ b/ampel/abstract/AbsIngester.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
+from ampel.abstract.AbsContextManager import AbsContextManager
 from ampel.abstract.AbsDocIngester import AbsDocIngester
-from ampel.base.AmpelABC import AmpelABC
 from ampel.base.decorator import abstractmethod
 from ampel.content.DataPoint import DataPoint
 from ampel.content.T1Document import T1Document
@@ -13,8 +13,10 @@ from ampel.log.AmpelLogger import AmpelLogger
 from ampel.protocol.StockIngesterProtocol import StockIngesterProtocol
 from ampel.types import Traceless
 
+if TYPE_CHECKING:
+    pass
 
-class AbsIngester(AmpelABC, ContextUnit, abstract=True):
+class AbsIngester(AbsContextManager, ContextUnit, abstract=True):
     error_callback: Traceless[None | Callable[[], None]] = None
     acknowledge_callback: Traceless[None | Callable[[Iterable[Any]], None]] = None
 
@@ -34,13 +36,6 @@ class AbsIngester(AmpelABC, ContextUnit, abstract=True):
         :param acknowledge_messages: messages to be passed to
             acknowledge_callback when documents ingested in the context are
             delivered
-        """
-        ...
-
-    @abstractmethod
-    def flush(self) -> None:
-        """
-        Wait for all documents to be stored
         """
         ...
 

--- a/ampel/ingest/IngestionWorker.py
+++ b/ampel/ingest/IngestionWorker.py
@@ -41,7 +41,11 @@ class IngestionWorker(AbsEventUnit):
                 [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGHUP],
                 logger,
             ) as stop_token,
-            self.context.loader.new(self.consumer, unit_type=AbsConsumer) as consumer,
+            self.context.loader.new(
+                self.consumer,
+                stop=stop_token,
+                unit_type=AbsConsumer,
+            ) as consumer,
             self.context.loader.new_context_unit(
                 self.ingester,
                 context=self.context,

--- a/ampel/ingest/IngestionWorker.py
+++ b/ampel/ingest/IngestionWorker.py
@@ -23,64 +23,60 @@ class IngestionWorker(AbsEventUnit):
     ingester: UnitModel = UnitModel(unit="MongoIngester")
 
     def proceed(self, event_hdlr: EventHandler) -> int:
-        """:returns: number of t2 docs processed"""
+        """:returns: number of messages processed"""
 
         run_id = event_hdlr.get_run_id()
-
-        logger = AmpelLogger.from_profile(
-            self.context,
-            self.log_profile,
-            run_id,
-            base_flag=LogFlag.CORE | self.base_log_flag,
-        )
 
         # Loop variables
         doc_counter = 0
 
-        with stop_on_signal(
-            [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGHUP], logger
-        ) as stop_token:
-            try:
-                consumer = self.context.loader.new(self.consumer, unit_type=AbsConsumer)
+        with(
+            AmpelLogger.from_profile(
+                self.context,
+                self.log_profile,
+                run_id,
+                base_flag=LogFlag.CORE | self.base_log_flag,
+            ) as logger,
+            stop_on_signal(
+                [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGHUP],
+                logger,
+            ) as stop_token,
+            self.context.loader.new(self.consumer, unit_type=AbsConsumer) as consumer,
+            self.context.loader.new_context_unit(
+                self.ingester,
+                context=self.context,
+                run_id=run_id,
+                tier=-1,
+                process_name=self.process_name,
+                error_callback=stop_token.set,
+                acknowledge_callback=consumer.acknowledge,
+                logger=logger,
+                sub_type=AbsIngester,
+            ) as ingester,
+        ):
 
-                ingester = self.context.loader.new_context_unit(
-                    self.ingester,
-                    context=self.context,
-                    run_id=run_id,
-                    tier=-1,
-                    process_name=self.process_name,
-                    error_callback=stop_token.set,
-                    acknowledge_callback=consumer.acknowledge,
-                    logger=logger,
-                    sub_type=AbsIngester,
-                )
+            # Process docs until next() returns None (breaks condition below)
+            while not stop_token.is_set():
+                item: None | QueueItem = consumer.consume()
 
-                # Process docs until next() returns None (breaks condition below)
-                while not stop_token.is_set():
-                    item: None | QueueItem = consumer.consume()
+                # No match
+                if item is None:
+                    if not stop_token.is_set():
+                        logger.log(LogFlag.SHOUT, "No more docs to process")
+                    break
 
-                    # No match
-                    if item is None:
-                        if not stop_token.is_set():
-                            logger.log(LogFlag.SHOUT, "No more docs to process")
-                        break
+                doc_counter += 1
 
-                    doc_counter += 1
+                with ingester.group([item]):
+                    for stock in item["stock"]:
+                        ingester.stock.ingest(stock)
+                    for dp in item["t0"]:
+                        ingester.t0.ingest(dp)
+                    for t1 in item["t1"]:
+                        ingester.t1.ingest(t1)
+                    for t2 in item["t2"]:
+                        ingester.t2.ingest(t2)
 
-                    with ingester.group([item]):
-                        for stock in item["stock"]:
-                            ingester.stock.ingest(stock)
-                        for dp in item["t0"]:
-                            ingester.t0.ingest(dp)
-                        for t1 in item["t1"]:
-                            ingester.t1.ingest(t1)
-                        for t2 in item["t2"]:
-                            ingester.t2.ingest(t2)
-
-            finally:
-                ingester.flush()
-                event_hdlr.add_extra(docs=doc_counter)
-
-                logger.flush()
+        event_hdlr.add_extra(docs=doc_counter)
 
         return doc_counter

--- a/ampel/log/AmpelLogger.py
+++ b/ampel/log/AmpelLogger.py
@@ -14,6 +14,7 @@ from os.path import basename
 from sys import _getframe
 from typing import TYPE_CHECKING, Any
 
+from ampel.abstract.AbsContextManager import AbsContextManager
 from ampel.log.handlers.AmpelStreamHandler import AmpelStreamHandler
 from ampel.log.LightLogRecord import LightLogRecord
 from ampel.log.LogFlag import LogFlag
@@ -36,7 +37,7 @@ DEBUG = LogFlag.DEBUG
 if TYPE_CHECKING:
 	from ampel.core.AmpelContext import AmpelContext
 
-class AmpelLogger:
+class AmpelLogger(AbsContextManager):
 
 	loggers: dict[int | str, 'AmpelLogger'] = {}
 	_counter: int = 0
@@ -137,6 +138,10 @@ class AmpelLogger:
 			self.provenance = False
 
 		self._auto_level()
+
+
+	def __exit__(self, exc_type, exc_value, traceback) -> None:
+		self.flush()
 
 
 	def _auto_level(self):

--- a/ampel/queue/AbsConsumer.py
+++ b/ampel/queue/AbsConsumer.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from typing import Generic
 
-from ampel.base.AmpelABC import AmpelABC
+from ampel.abstract.AbsContextManager import AbsContextManager
 from ampel.base.AmpelUnit import AmpelUnit
 from ampel.base.decorator import abstractmethod
 from ampel.types import (
@@ -9,7 +9,7 @@ from ampel.types import (
 )
 
 
-class AbsConsumer(AmpelABC, AmpelUnit, Generic[T], abstract=True):
+class AbsConsumer(AbsContextManager, AmpelUnit, Generic[T], abstract=True):
 
 	@abstractmethod
 	def consume(self) -> None | T:

--- a/ampel/queue/AbsConsumer.py
+++ b/ampel/queue/AbsConsumer.py
@@ -1,19 +1,21 @@
 from collections.abc import Iterable
+from threading import Event
 from typing import Generic
 
 from ampel.abstract.AbsContextManager import AbsContextManager
 from ampel.base.AmpelUnit import AmpelUnit
 from ampel.base.decorator import abstractmethod
-from ampel.types import (
-	T,
-)
+from ampel.types import T, Traceless
 
 
 class AbsConsumer(AbsContextManager, AmpelUnit, Generic[T], abstract=True):
 
+	#: Event that can be set to break out of consume()
+	stop: Traceless[Event]
+
 	@abstractmethod
 	def consume(self) -> None | T:
-		"""Get a single message from the queue"""
+		"""Get a single message from the queue, returning None if the queue is empty, or stop is set"""
 		...
 	
 	@abstractmethod

--- a/ampel/queue/AbsProducer.py
+++ b/ampel/queue/AbsProducer.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TypeVar
 
-from ampel.base.AmpelABC import AmpelABC
+from ampel.abstract.AbsContextManager import AbsContextManager
 from ampel.base.AmpelUnit import AmpelUnit
 from ampel.base.decorator import abstractmethod
 from ampel.content.DataPoint import DataPoint
@@ -12,7 +12,7 @@ from ampel.content.T2Document import T2Document
 
 _T = TypeVar("_T", StockDocument, DataPoint, T1Document, T2Document)
 
-class AbsProducer(AmpelABC, AmpelUnit, abstract=True):
+class AbsProducer(AbsContextManager, AmpelUnit, abstract=True):
 
     @dataclass
     class Item:
@@ -36,6 +36,3 @@ class AbsProducer(AmpelABC, AmpelUnit, abstract=True):
     def produce(
         self, item: Item, delivery_callback: None | Callable[[], None]
     ) -> None: ...
-
-    @abstractmethod
-    def flush(self) -> None: ...

--- a/ampel/queue/NullProducer.py
+++ b/ampel/queue/NullProducer.py
@@ -14,5 +14,5 @@ class NullProducer(AbsProducer):
         if delivery_callback:
             delivery_callback()
 
-    def flush(self):
-        pass
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return None

--- a/ampel/queue/QueueIngester.py
+++ b/ampel/queue/QueueIngester.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from bson import ObjectId
 
@@ -164,6 +164,13 @@ class QueueIngester(AbsIngester):
 
         self._item = AbsProducer.Item.new()
 
+    def __enter__(self) -> "Self":
+        self._producer.__enter__()
+        return super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool | None:
+        return self._producer.__exit__(exc_type, exc_value, traceback)
+
     @contextmanager
     def group(self, acknowledge_messages: None | Iterable[Any] = None) -> Generator:
         """
@@ -183,9 +190,6 @@ class QueueIngester(AbsIngester):
         prev = self._item
         self._item = AbsProducer.Item.new()
         return prev
-
-    def flush(self) -> None:
-        self._producer.flush()
 
     def _add_stock(self, doc: StockDocument) -> None:
         self._item.stock.append(doc)

--- a/ampel/t2/T2QueueWorker.py
+++ b/ampel/t2/T2QueueWorker.py
@@ -75,7 +75,9 @@ class T2QueueWorker(T2Worker):
 			) as logger,
 			self._run_until_signal(run_id, logger) as stop_token,
 			self.context.loader.new(
-				self.consumer, unit_type=AbsConsumer
+				self.consumer,
+				stop=stop_token,
+				unit_type=AbsConsumer,
 			) as consumer,
 			self.context.loader.new_context_unit(
 				self.ingester,

--- a/ampel/t2/T2QueueWorker.py
+++ b/ampel/t2/T2QueueWorker.py
@@ -1,5 +1,4 @@
 import gc
-import signal
 from collections.abc import Generator, Sequence
 from time import time
 from typing import Any, Literal, TypedDict, overload
@@ -8,7 +7,7 @@ from bson import ObjectId
 from mongomock.filtering import filter_applies
 
 from ampel.abstract.AbsIngester import AbsIngester
-from ampel.abstract.AbsWorker import stat_time, stop_on_signal
+from ampel.abstract.AbsWorker import stat_time
 from ampel.content.DataPoint import DataPoint
 from ampel.content.MetaRecord import MetaRecord
 from ampel.content.StockDocument import StockDocument
@@ -58,29 +57,27 @@ class T2QueueWorker(T2Worker):
 		event_hdlr.set_tier(self.tier)
 		run_id = event_hdlr.get_run_id()
 
-		logger = AmpelLogger.from_profile(
-			self.context, self.log_profile, run_id,
-			base_flag = getattr(LogFlag, f'T{self.tier}') | LogFlag.CORE | self.base_log_flag
-		)
-
 		if self.send_beacon:
 			self.col_beacon.update_one(
 				{'_id': self.beacon_id},
 				{'$set': {'timestamp': int(time())}}
 			)
 
-		consumer = self.context.loader.new(self.consumer, unit_type=AbsConsumer)
-
 		# Loop variables
 		doc_counter = 0
 		garbage_collect = self.garbage_collect
 		doc_limit = self.doc_limit
 
-		with stop_on_signal(
-			[signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGHUP],
-			logger
-		) as stop_token:
-			ingester = self.context.loader.new_context_unit(
+		with (
+			AmpelLogger.from_profile(
+				self.context, self.log_profile, run_id,
+				base_flag = getattr(LogFlag, f'T{self.tier}') | LogFlag.CORE | self.base_log_flag
+			) as logger,
+			self._run_until_signal(run_id, logger) as stop_token,
+			self.context.loader.new(
+				self.consumer, unit_type=AbsConsumer
+			) as consumer,
+			self.context.loader.new_context_unit(
 				self.ingester,
 				context = self.context,
 				run_id = run_id,
@@ -90,68 +87,60 @@ class T2QueueWorker(T2Worker):
 				acknowledge_callback = consumer.acknowledge,
 				logger = logger,
 				sub_type = AbsIngester,
-			)
+			) as ingester
+		):
 
-			try:
-				self._current_run_id = run_id
-				# Process docs until next() returns None (breaks condition below)
-				while not stop_token.is_set():
+			# Process docs until next() returns None (breaks condition below)
+			while not stop_token.is_set():
 
-					# get t1/t2 document (code is usually NEW or NEW_PRIO), excluding
-					# docs with retry times in the future
-					with stat_time.labels(self.tier, "consume", None).time():
-						item: None | QueueItem = consumer.consume()
+				# get t1/t2 document (code is usually NEW or NEW_PRIO), excluding
+				# docs with retry times in the future
+				with stat_time.labels(self.tier, "consume", None).time():
+					item: None | QueueItem = consumer.consume()
 
-					# No match
-					if item is None:
-						if not stop_token.is_set():
-							logger.log(LogFlag.SHOUT, "No more docs to process")
-						break
+				# No match
+				if item is None:
+					if not stop_token.is_set():
+						logger.log(LogFlag.SHOUT, "No more docs to process")
+					break
 
-					self._current_item = item
+				self._current_item = item
 
-					input_docs = item["t2"]
-					# Replace inputs with resolved version from the database.
-					# Doing this here allows process_doc() to find
-					# already-processed docs if it recurse into
-					# load_input_docs() for tied units.
-					item["t2"] = [self._sub_existing_doc(doc) for doc in item["t2"]]
+				input_docs = item["t2"]
+				# Replace inputs with resolved version from the database.
+				# Doing this here allows process_doc() to find
+				# already-processed docs if it recurse into
+				# load_input_docs() for tied units.
+				item["t2"] = [self._sub_existing_doc(doc) for doc in item["t2"]]
 
-					with ingester.group([item]):
-						for input_doc, doc in zip(input_docs, item["t2"], strict=True):
-							if doc is input_doc:
-								# not found in the database; process for the first time
-								with stat_time.labels(self.tier, "process_doc", doc["unit"]).time():
-									self.process_doc(doc, ingester, logger)
-						doc_counter += 1
+				with ingester.group([item]):
+					for input_doc, doc in zip(input_docs, item["t2"], strict=True):
+						if doc is input_doc:
+							# not found in the database; process for the first time
+							with stat_time.labels(self.tier, "process_doc", doc["unit"]).time():
+								self.process_doc(doc, ingester, logger)
+					doc_counter += 1
 
-						for stock in item["stock"]:
-							ingester.stock.ingest(stock)
-						for dp in item["t0"]:
-							ingester.t0.ingest(dp)
-						for t1 in item["t1"]:
-							ingester.t1.ingest(t1)
-						# NB: ingest the input docs as they were before
-						# substitution in order to pick up any requested updates
-						# to meta, channels, tags, expiry, etc.
-						for t2 in input_docs:
-							ingester.t2.ingest(t2)
+					for stock in item["stock"]:
+						ingester.stock.ingest(stock)
+					for dp in item["t0"]:
+						ingester.t0.ingest(dp)
+					for t1 in item["t1"]:
+						ingester.t1.ingest(t1)
+					# NB: ingest the input docs as they were before
+					# substitution in order to pick up any requested updates
+					# to meta, channels, tags, expiry, etc.
+					for t2 in input_docs:
+						ingester.t2.ingest(t2)
 
-					# Check possibly defined doc_limit
-					if doc_limit and doc_counter >= doc_limit:
-						break
+				# Check possibly defined doc_limit
+				if doc_limit and doc_counter >= doc_limit:
+					break
 
-					if garbage_collect:
-						gc.collect()
-			finally:
-				ingester.flush()
-				event_hdlr.add_extra(docs=doc_counter)
+				if garbage_collect:
+					gc.collect()
 
-				logger.flush()
-				self._instances.clear()
-				self._adapters.clear()
-				self._current_run_id = None
-
+		event_hdlr.add_extra(docs=doc_counter)
 		return doc_counter
 
 	def _sub_existing_doc(self, doc: T2Document) -> T2Document:

--- a/ampel/test/test_IngestionHandler.py
+++ b/ampel/test/test_IngestionHandler.py
@@ -237,8 +237,8 @@ def test_queue_ingester(
             if delivery_callback:
                 delivery_callback()
 
-        def flush(self):
-            pass
+        def __exit__(self, exc_type, exc_value, traceback) -> None:
+            return
 
     acknowledge_callback = mocker.MagicMock()
 

--- a/ampel/test/test_T2Processor.py
+++ b/ampel/test/test_T2Processor.py
@@ -211,7 +211,7 @@ def test_queue_worker(
         def produce(self, item: AbsProducer.Item, delivery_callback=None):
             items.append(item)
 
-        def flush(self):
+        def __exit__(self, exc_type, exc_val, exc_tb):
             pass
 
     @mock_context.register_unit
@@ -223,6 +223,9 @@ def test_queue_worker(
             return {"stock": item.stock, "t0": item.t0, "t1": item.t1, "t2": item.t2}
 
         def acknowledge(self, docs: Iterable[QueueItem]) -> None:
+            pass
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
             pass
 
     ack = mocker.patch.object(DummyConsumer, "acknowledge")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-core"
-version = "0.10.6a6"
+version = "0.10.6a7"
 description = "Alice in Modular Provenance-Enabled Land"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]


### PR DESCRIPTION
There are lots of places where some setup needs to happen before a
code block, and some action needs to happen afterwards:

- DBUpdatesBuffer: start/stop pusher thread, flush buffered updates
- AmpelLogger: flush buffered records
- AbsWorker and co: set current run id, clear cached unit instances
- AbsConsumer: subscribe/unsubscribe from queue
- AbsProducer: flush buffered messages, potentially stop threads

While all of these can be handled by try/finally blocks, this puts
onus on the user to clean up afterwards.  Use context managers to
encapsulate these steps in the objects themselves.