### PR TITLE
`T1Compute` fixes

### DIFF
--- a/ampel/abstract/AbsContextManager.py
+++ b/ampel/abstract/AbsContextManager.py
@@ -1,6 +1,6 @@
 
 from types import TracebackType
-from typing import Self
+from typing_extensions import Self
 
 from ampel.base.AmpelABC import AmpelABC
 from ampel.base.decorator import abstractmethod

--- a/ampel/abstract/AbsContextManager.py
+++ b/ampel/abstract/AbsContextManager.py
@@ -1,5 +1,6 @@
 
 from types import TracebackType
+
 from typing_extensions import Self
 
 from ampel.base.AmpelABC import AmpelABC

--- a/ampel/abstract/AbsContextManager.py
+++ b/ampel/abstract/AbsContextManager.py
@@ -1,8 +1,9 @@
+
 from types import TracebackType
+from typing import Self
 
 from ampel.base.AmpelABC import AmpelABC
 from ampel.base.decorator import abstractmethod
-from typing_extensions import Self
 
 
 class AbsContextManager(AmpelABC, abstract=True):
@@ -14,9 +15,5 @@ class AbsContextManager(AmpelABC, abstract=True):
         return self
 
     @abstractmethod
-    def __exit__(
-        self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
-    ) -> None | bool: ...
+    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None | bool:
+        ...

--- a/ampel/abstract/AbsContextManager.py
+++ b/ampel/abstract/AbsContextManager.py
@@ -1,9 +1,8 @@
-
 from types import TracebackType
-from typing import Self
 
 from ampel.base.AmpelABC import AmpelABC
 from ampel.base.decorator import abstractmethod
+from typing_extensions import Self
 
 
 class AbsContextManager(AmpelABC, abstract=True):
@@ -15,5 +14,9 @@ class AbsContextManager(AmpelABC, abstract=True):
         return self
 
     @abstractmethod
-    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None | bool:
-        ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> None | bool: ...

--- a/ampel/config/alter/HashT2Config.py
+++ b/ampel/config/alter/HashT2Config.py
@@ -21,7 +21,7 @@ class HashT2Config(AbsConfigUpdater):
 
 	def alter(self, context: AmpelContext, content: dict[str, Any], logger: AmpelLogger) -> dict[str, Any]:
 
-		pm = ProcessMorpher(process={}, logger=logger, proc_name='<off-config>')
+		pm = ProcessMorpher(process={}, logger=logger, verbose=bool(logger.verbose), proc_name='<off-config>')
 		cc = T02ConfigCollector(conf_section="confid")
 		# Note: *process* templating could be possible there as well, add if ever needed
 		ac = context.config._config  # noqa: SLF001

--- a/ampel/config/builder/ProcessMorpher.py
+++ b/ampel/config/builder/ProcessMorpher.py
@@ -237,7 +237,7 @@ class ProcessMorpher:
 		walk_and_process_dict(
 			arg = target or self.process["processor"]["config"]["directives"],
 			callback = self._gather_t2_config_callback,
-			match = ['point_t2', 'stock_t2', 'state_t2', 't2_dependency'],
+			match = ['point_t2', 'stock_t2', 'state_t2', 't2_dependency', 'compute', 'combine'],
 			conf_dicts = conf_dicts
 		)
 
@@ -312,8 +312,14 @@ class ProcessMorpher:
 			self.logger.info(f"# path: {path}.{k}")
 
 		if d[k]:
-			for i, el in enumerate(d[k]):
+			if isinstance(v := d[k], dict):
 				if self.verbose > 1:
-					self.logger.info(f"# path: {path}.{k}.{i}")
-					self.logger.info(el)
-				kwargs['conf_dicts'][f"{path}.{k}.{i}"] = el
+					self.logger.info(f"# path: {path}.{k}")
+					self.logger.info(v)
+				kwargs["conf_dicts"][f"{path}.{k}"] = v
+			if isinstance(v, list):
+				for i, el in enumerate(d[k]):
+					if self.verbose > 1:
+						self.logger.info(f"# path: {path}.{k}.{i}")
+						self.logger.info(el)
+					kwargs['conf_dicts'][f"{path}.{k}.{i}"] = el

--- a/ampel/ingest/ChainedIngestionHandler.py
+++ b/ampel/ingest/ChainedIngestionHandler.py
@@ -368,7 +368,10 @@ class ChainedIngestionHandler:
 
 			t1b.compute = T1ComputeBlock()
 			t1b.compute.unit_name = t1_combine.compute.unit
-			t1b.compute.config = t1_combine.compute.config
+			if isinstance(t1_combine.compute.config, int):
+				t1b.compute.config = t1_combine.compute.config
+			else:
+				raise ValueError("Integer expected for t1_combine.compute.config")
 
 			# On the fly t1 computation requested
 			if isinstance(t1_combine, T1CombineComputeNow):

--- a/ampel/ingest/ChainedIngestionHandler.py
+++ b/ampel/ingest/ChainedIngestionHandler.py
@@ -368,10 +368,7 @@ class ChainedIngestionHandler:
 
 			t1b.compute = T1ComputeBlock()
 			t1b.compute.unit_name = t1_combine.compute.unit
-			if isinstance(t1_combine.compute.config, int):
-				t1b.compute.config = t1_combine.compute.config
-			else:
-				raise ValueError("Integer expected for t1_combine.compute.config")
+			t1b.compute.config = t1_combine.compute.config
 
 			# On the fly t1 computation requested
 			if isinstance(t1_combine, T1CombineComputeNow):

--- a/ampel/ingest/ChainedIngestionHandler.py
+++ b/ampel/ingest/ChainedIngestionHandler.py
@@ -382,7 +382,7 @@ class ChainedIngestionHandler:
 					t1_compute_unit = self._t1_compute_units_cache[i]
 				else:
 					t1_compute_unit = self.context.loader.new_logical_unit(
-						model = t1_combine,
+						model = t1_combine.compute,
 						logger = buf_logger,
 						sub_type = AbsT1ComputeUnit
 					)

--- a/ampel/mongo/update/MongoIngester.py
+++ b/ampel/mongo/update/MongoIngester.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from contextlib import contextmanager
 from typing import Any
+
 from typing_extensions import Self
 
 from ampel.abstract.AbsDocIngester import AbsDocIngester

--- a/ampel/mongo/update/MongoIngester.py
+++ b/ampel/mongo/update/MongoIngester.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from contextlib import contextmanager
-from typing import Any, Self
+from typing import Any
+from typing_extensions import Self
 
 from ampel.abstract.AbsDocIngester import AbsDocIngester
 from ampel.abstract.AbsIngester import AbsIngester

--- a/ampel/mongo/update/MongoIngester.py
+++ b/ampel/mongo/update/MongoIngester.py
@@ -1,7 +1,9 @@
 from collections.abc import Iterable
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Self
 
+from ampel.abstract.AbsDocIngester import AbsDocIngester
+from ampel.abstract.AbsIngester import AbsIngester
 from ampel.base.AmpelBaseModel import AmpelBaseModel
 from ampel.base.AuxUnitRegister import AuxUnitRegister
 from ampel.content.DataPoint import DataPoint
@@ -9,33 +11,27 @@ from ampel.content.StockDocument import StockDocument
 from ampel.content.T1Document import T1Document
 from ampel.content.T2Document import T2Document
 from ampel.model.UnitModel import UnitModel
-from ampel.types import OneOrMany, Tag
-from typing_extensions import Self
-
-from ampel.abstract.AbsDocIngester import AbsDocIngester
-from ampel.abstract.AbsIngester import AbsIngester
 from ampel.mongo.update.DBUpdatesBuffer import DBUpdatesBuffer
 from ampel.mongo.update.MongoStockUpdater import MongoStockUpdater
 from ampel.protocol.StockIngesterProtocol import StockIngesterProtocol
+from ampel.types import OneOrMany, Tag
 
 
 class _StockIngester:
-    def __init__(
-        self, ingester: AbsDocIngester[StockDocument], updater: MongoStockUpdater
-    ) -> None:
+
+    def __init__(self, ingester: AbsDocIngester[StockDocument], updater: MongoStockUpdater) -> None:
         self.ingester = ingester
         self.update = updater
-
+    
     def ingest(self, doc: StockDocument) -> None:
         self.ingester.ingest(doc)
-
 
 class _UpdatesBufferModel(AmpelBaseModel):
     max_size: int = 500
     push_interval: float = 3
 
-
 class MongoIngester(AbsIngester):
+
     updates_buffer: _UpdatesBufferModel = _UpdatesBufferModel()
 
     #: Tag(s) to add to the stock :class:`~ampel.content.JournalRecord.JournalRecord`
@@ -57,13 +53,10 @@ class MongoIngester(AbsIngester):
         )
 
         stock_updater = MongoStockUpdater(
-            ampel_db=self.context.db,
-            tier=self.tier,
-            run_id=self.run_id,
-            process_name=self.process_name,
-            logger=self.logger,
-            raise_exc=self.raise_exc,
-            extra_tag=self.jtag,
+            ampel_db = self.context.db, tier = self.tier, run_id = self.run_id,
+            process_name = self.process_name, logger = self.logger,
+            raise_exc = self.raise_exc, extra_tag = self.jtag
+
         )
 
         # Create ingesters
@@ -120,7 +113,7 @@ class MongoIngester(AbsIngester):
                 self._updates_buffer.acknowledge_on_push(message)
             if len(self._stock.update._updates) >= self.updates_buffer.max_size:  # noqa: SLF001
                 self._stock.update.flush()
-
+    
     def flush(self) -> None:
         self._updates_buffer.push_updates(force=True)
         self._stock.update.flush()

--- a/ampel/queue/QueueIngester.py
+++ b/ampel/queue/QueueIngester.py
@@ -1,12 +1,8 @@
 from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Literal, Self
+from typing import Any, Literal
 
-from bson import ObjectId
-
-from ampel.abstract.AbsDocIngester import AbsDocIngester
-from ampel.abstract.AbsIngester import AbsIngester
 from ampel.content.DataPoint import DataPoint
 from ampel.content.JournalRecord import JournalRecord
 from ampel.content.StockDocument import StockDocument
@@ -14,13 +10,19 @@ from ampel.content.T1Document import T1Document
 from ampel.content.T2Document import T2Document
 from ampel.enum.JournalActionCode import JournalActionCode
 from ampel.model.UnitModel import UnitModel
+from ampel.struct.JournalAttributes import JournalAttributes
+from ampel.types import ChannelId, StockId, Tag
+from bson import ObjectId
+from typing_extensions import Self
+
+from ampel.abstract.AbsDocIngester import AbsDocIngester
+from ampel.abstract.AbsIngester import AbsIngester
 from ampel.mongo.update.MongoStockUpdater import BaseStockUpdater
 from ampel.protocol.StockIngesterProtocol import StockIngesterProtocol
 from ampel.queue.AbsProducer import AbsProducer
-from ampel.struct.JournalAttributes import JournalAttributes
-from ampel.types import ChannelId, StockId, Tag
 
 # ruff: noqa: SLF001
+
 
 class QueueIngester(AbsIngester):
     producer: UnitModel
@@ -34,14 +36,12 @@ class QueueIngester(AbsIngester):
             process_name: str,
             extra_tag: None | Tag | Sequence[Tag] = None,
             bump_updated: bool = True,
-
         ) -> None:
             super().__init__(
                 tier=tier, run_id=run_id, process_name=process_name, extra_tag=extra_tag
             )
             self.queue = queue
             self.bump_updated = bump_updated
-
 
         def add_journal_record(
             self,
@@ -71,7 +71,13 @@ class QueueIngester(AbsIngester):
 
             names = {name} if isinstance(name, str) else set(name) if name else None
             tags = {tag} if isinstance(tag, Tag) else set(tag) if tag else None
-            channels = [channel] if isinstance(channel, ChannelId) else channel if channel else []
+            channels = (
+                [channel]
+                if isinstance(channel, ChannelId)
+                else channel
+                if channel
+                else []
+            )
 
             for doc in self._match_stocks(
                 {stock} if isinstance(stock, StockId) else set(stock)
@@ -81,7 +87,7 @@ class QueueIngester(AbsIngester):
                     doc["name"] = list(names.union(doc.get("name", [])))
                 if tags:
                     doc["tag"] = list(tags.union(doc.get("tag", [])))
-                
+
                 if self.bump_updated:
                     for chan in ("any", *channels):
                         self._update_ts(doc, chan, jrec["ts"])

--- a/ampel/queue/QueueIngester.py
+++ b/ampel/queue/QueueIngester.py
@@ -2,9 +2,9 @@ from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from functools import partial
 from typing import Any, Literal
-from typing_extensions import Self
 
 from bson import ObjectId
+from typing_extensions import Self
 
 from ampel.abstract.AbsDocIngester import AbsDocIngester
 from ampel.abstract.AbsIngester import AbsIngester

--- a/ampel/queue/QueueIngester.py
+++ b/ampel/queue/QueueIngester.py
@@ -1,7 +1,8 @@
 from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Literal, Self
+from typing import Any, Literal
+from typing_extensions import Self
 
 from bson import ObjectId
 

--- a/ampel/test/conftest.py
+++ b/ampel/test/conftest.py
@@ -17,7 +17,7 @@ from ampel.dev.DevAmpelContext import DevAmpelContext
 from ampel.ingest.ChainedIngestionHandler import ChainedIngestionHandler
 from ampel.ingest.StockCompiler import StockCompiler
 from ampel.ingest.T2Compiler import T2Compiler
-from ampel.log.AmpelLogger import AmpelLogger
+from ampel.log.AmpelLogger import DEBUG, AmpelLogger
 from ampel.model.ingest.CompilerOptions import CompilerOptions
 from ampel.model.ingest.IngestBody import IngestBody
 from ampel.model.ingest.IngestDirective import IngestDirective
@@ -120,7 +120,7 @@ def dev_context(request):
 
 @pytest.fixture
 def ampel_logger():
-    return AmpelLogger.get_logger()
+    return AmpelLogger.get_logger(console=dict(level=DEBUG))
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
+packages = ["ampel"]
 namespace_packages = true
 show_error_codes = true
 warn_unused_ignores = true


### PR DESCRIPTION
Make `T1Compute`s work. This includes the `ChainedIngestionHandler` using `t1_combine.compute` to instantiate the compute unit instead of just `t1_combine`. The `ProcessMorpher` now also looks at `combine` and `compute` to hash units. As a side note, the name `hash_t2_config` is then a bit misleading because the T1 units are also hashed.