### PR TITLE
Use muxed datapoints for point t2s under muxer

### DIFF
--- a/ampel/ingest/ChainedIngestionHandler.py
+++ b/ampel/ingest/ChainedIngestionHandler.py
@@ -531,12 +531,12 @@ class ChainedIngestionHandler:
 					jentry['upsert'] = [el['id'] for el in dps_insert]
 					jentry['action'] |= JournalActionCode.T0_ADD_CHANNEL
 
-					if mux.point_t2:
-						jentry['action'] |= JournalActionCode.T2_ADD_CHANNEL
-						self.ingest_point_t2s(
-							dps_insert, fres, stock_id, ib.channel, ib.ttl, mux.point_t2, add_other_tag,
-							jm_extra if self.include_extra_meta > 1 else None
-						)
+				if dps_combine and mux.point_t2:
+					jentry['action'] |= JournalActionCode.T2_ADD_CHANNEL
+					self.ingest_point_t2s(
+						dps_combine, fres, stock_id, ib.channel, ib.ttl, mux.point_t2, add_other_tag,
+						jm_extra if self.include_extra_meta > 1 else None
+					)
 
 				# Muxed T1 and associated T2 ingestions
 				if dps_combine and mux.combine:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-core"
-version = "0.10.6a22"
+version = "0.10.6a23"
 description = "Alice in Modular Provenance-Enabled Land"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]


### PR DESCRIPTION
When point T2s are attached to a muxer, they use the datapoints to insert to generate point t2 documents.  This is fine if there is no datapoint selection, but for example when a directive selects the first datapoint under some time-based ordering, the datapoint it should have selected may already by in the database, and so will not be picked up.  A state-bound T2 that depends on the point T2 with the same selection will look for a doc bound to the actual first point (which was not included in the points to insert), not find one, and return T2_MISSING_DEPENDENCY.

Work around this by using dps_combine to generate point t2s, which should always be a superset of dps_insert.