### PR TITLE
Allow installation in directories where a parent directory ends with "ampel"

### DIFF
--- a/ampel/config/builder/DistConfigBuilder.py
+++ b/ampel/config/builder/DistConfigBuilder.py
@@ -205,7 +205,7 @@ class DistConfigBuilder(ConfigBuilder):
 			for fpath in units_parents:
 				if fpath in units_ancestry:
 					self.first_pass_config['unit'].add(
-						"ampel." + fpath.split("ampel/")[1].replace("/", ".").removesuffix(".py"),
+						"ampel." + fpath.rpartition("ampel/")[2].replace("/", ".").removesuffix(".py"),
 						dist_name, metadata.distribution(dist_name).version, fpath
 					)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-core"
-version = "0.10.6a23"
+version = "0.10.6a24"
 description = "Alice in Modular Provenance-Enabled Land"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]


### PR DESCRIPTION
Canonical ampel paths start with ampel/, but this may also occur earlier in the file path.